### PR TITLE
Fix inline code rendering and add syntax highlighting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,9 @@ github_username:  ruri-sayo
 markdown: kramdown
 kramdown:
   math_engine: mathjax
+  syntax_highlighter: rouge
+
+highlighter: rouge
 
 # 記事URL：/posts/2025/10/14/title/
 permalink: /posts/:year/:month/:day/:title/

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,6 +16,7 @@
 
 <!-- お好みでカスタム CSS を足す場合（SCSS を使うなら /assets/css/style.css をビルド）
 <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">-->
+<link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}">
 
 
 <!-- この設定を先に置く（MathJax script の前） -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@
             </header>
 
 
-                <main>
+                <main class="max-w-5xl mx-auto">
                     {{ content }}
                 </main>
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,6 +1,6 @@
 ---
 layout: default
 ---
-<article class="prose max-w-none">
+<article class="prose max-w-3xl mx-auto">
 {{ content }}
 </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-<article class="prose prose-neutral max-w-none">
+<article class="prose prose-neutral max-w-3xl mx-auto">
 <header class="mb-6">
 <h1 class="text-3xl font-bold">{{ page.title }}</h1>
 <p class="text-gray-500 text-sm">{{ page.date | date: '%Y-%m-%d' }}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,114 @@
+/* Tailwind Typography のデフォルトで表示されるバッククォートを消す */
+.prose :where(code):not(:where([class~="not-prose"] *))::before,
+.prose :where(code):not(:where([class~="not-prose"] *))::after {
+  content: none;
+}
+
+/* インラインコードの読みやすさを改善 */
+.prose code,
+.prose :where(code):not(:where([class~="not-prose"] *)) {
+  background: #f5f5f5;
+  color: #1f2937;
+  padding: 0.15rem 0.35rem;
+  border-radius: 0.35rem;
+  font-size: 0.95em;
+  font-weight: 500;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.04);
+}
+
+/* Rouge ハイライト共通 */
+.highlight {
+  background: #f6f8fa;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  overflow-x: auto;
+  margin: 1.25rem 0;
+  border: 1px solid #e5e7eb;
+}
+
+.highlight pre {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+}
+
+.highlight code {
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+}
+
+/* Rouge: GitHub Light 風配色 */
+.highlight .c { color: #6a737d; font-style: italic; }
+.highlight .err { color: #b31d28; background-color: #fcdedf; }
+.highlight .k { color: #d73a49; }
+.highlight .o { color: #d73a49; }
+.highlight .cm { color: #6a737d; font-style: italic; }
+.highlight .cp { color: #005cc5; }
+.highlight .c1 { color: #6a737d; font-style: italic; }
+.highlight .cs { color: #6a737d; font-style: italic; }
+.highlight .gd { color: #b31d28; background-color: #ffeef0; }
+.highlight .ge { font-style: italic; }
+.highlight .gh { color: #005cc5; font-weight: bold; }
+.highlight .gi { color: #22863a; background-color: #f0fff4; }
+.highlight .go { color: #24292e; }
+.highlight .gp { color: #4f46e5; }
+.highlight .gs { font-weight: bold; }
+.highlight .gu { color: #005cc5; font-weight: bold; }
+.highlight .kc { color: #d73a49; }
+.highlight .kd { color: #d73a49; }
+.highlight .kn { color: #d73a49; }
+.highlight .kp { color: #d73a49; }
+.highlight .kr { color: #d73a49; }
+.highlight .kt { color: #d73a49; }
+.highlight .m { color: #005cc5; }
+.highlight .s { color: #032f62; }
+.highlight .na { color: #6f42c1; }
+.highlight .nb { color: #005cc5; }
+.highlight .nc { color: #6f42c1; }
+.highlight .no { color: #005cc5; }
+.highlight .nd { color: #6f42c1; }
+.highlight .ni { color: #6f42c1; }
+.highlight .ne { color: #b31d28; }
+.highlight .nf { color: #6f42c1; }
+.highlight .nn { color: #005cc5; }
+.highlight .nt { color: #22863a; }
+.highlight .nv { color: #005cc5; }
+.highlight .ow { color: #d73a49; }
+.highlight .w { color: #586069; }
+.highlight .mb { color: #005cc5; }
+.highlight .mf { color: #005cc5; }
+.highlight .mh { color: #005cc5; }
+.highlight .mi { color: #005cc5; }
+.highlight .mo { color: #005cc5; }
+.highlight .sb { color: #032f62; }
+.highlight .sc { color: #032f62; }
+.highlight .sd { color: #032f62; }
+.highlight .s2 { color: #032f62; }
+.highlight .se { color: #032f62; }
+.highlight .sh { color: #032f62; }
+.highlight .si { color: #005cc5; }
+.highlight .sx { color: #005cc5; }
+.highlight .sr { color: #032f62; }
+.highlight .s1 { color: #032f62; }
+.highlight .ss { color: #005cc5; }
+.highlight .bp { color: #005cc5; }
+.highlight .vc { color: #005cc5; }
+.highlight .vg { color: #005cc5; }
+.highlight .vi { color: #005cc5; }
+.highlight .il { color: #005cc5; }
+
+/* ブログ本文のベース幅と余白（安全策） */
+main > .prose {
+  max-width: 70ch;
+}
+
+main {
+  padding-inline: 0.5rem;
+}
+
+@media (min-width: 768px) {
+  main {
+    padding-inline: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- remove the typography pseudo backticks so inline code renders cleanly
- enable Rouge syntax highlighting in the Jekyll configuration and add matching styles
- center article content with narrower prose widths for better readability

## Testing
- bundle install *(fails in this environment with HTTP 403 from rubygems.org when fetching gems)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b56b89f748320a810e5a770d92458)