### PR TITLE
Use Astro BASE_URL for Word Quiz data paths

### DIFF
--- a/src/components/game/WordQuiz.tsx
+++ b/src/components/game/WordQuiz.tsx
@@ -23,9 +23,11 @@ interface RawAinuItem {
 
 type Lang = 'swedish' | 'ainu';
 
+const baseUrl = import.meta.env.BASE_URL ?? '/';
+
 const QUIZ_CONFIG = {
     swedish: {
-        path: '/game/word_quiz/data/swedish.json',
+        path: `${baseUrl}game/word_quiz/data/swedish.json`,
         storageKey: 'quiz_highscore_swedish',
         normalize: (item: RawSwedishItem): QuizItem => ({
             term: item["単語"],
@@ -34,7 +36,7 @@ const QUIZ_CONFIG = {
         })
     },
     ainu: {
-        path: '/game/word_quiz/data/ainu.json',
+        path: `${baseUrl}game/word_quiz/data/ainu.json`,
         storageKey: 'quiz_highscore_ainu',
         normalize: (item: RawAinuItem): QuizItem => ({
             term: `${item.word}\n(${item.reading})`,


### PR DESCRIPTION
### Motivation
- Ensure the Word Quiz JSON data loads when the site is served from a subdirectory (e.g. GitHub Pages) by using Astro's `BASE_URL` instead of hard-coded absolute paths.

### Description
- Add `const baseUrl = import.meta.env.BASE_URL ?? '/'` and update `QUIZ_CONFIG` paths to use ```${baseUrl}game/word_quiz/data/...``` in `src/components/game/WordQuiz.tsx` so fetches target the correct base path.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972f8c716808320af62c960fa60fbec)